### PR TITLE
fix: 皮肤菜单移右下角可拖动 + 遮住标题栏圆角漏图

### DIFF
--- a/src/skin-css.mjs
+++ b/src/skin-css.mjs
@@ -89,9 +89,11 @@ body[data-application-name=workbuddy] {
 #root {
   color: var(--wb-text) !important;
   background:
+    linear-gradient(180deg, var(--wb-surface) 0 40px, transparent 40px),
     linear-gradient(90deg, color-mix(in srgb, var(--wb-surface) 96%, transparent) 0 22%, transparent 46%),
     linear-gradient(180deg, transparent 0 45%, color-mix(in srgb, var(--wb-surface) 78%, transparent) 78% 100%),
     url(${JSON.stringify(heroDataUrl)}) right center / cover no-repeat fixed !important;
+  background-position: 0 0, 0 0, 0 0, right 32px !important;
 }
 
 /* 关键：teams-container 是 #root 直接子层，默认有不透明灰底，会完全盖住背景图 */

--- a/src/skin-menu.mjs
+++ b/src/skin-menu.mjs
@@ -52,7 +52,7 @@ export function buildSkinMenuScript({ entries, activeId, styleId, menuId, cssTem
   document.getElementById(data.menuId)?.remove();
   const root = document.createElement("div");
   root.id = data.menuId;
-  root.style.cssText = "position:fixed;top:48px;right:16px;z-index:2147483000;font:500 13px/1.4 system-ui;user-select:none;";
+  root.style.cssText = "position:fixed;bottom:16px;right:16px;top:auto;z-index:2147483000;font:500 13px/1.4 system-ui;user-select:none;";
 
   const button = document.createElement("button");
   button.type = "button";
@@ -263,8 +263,35 @@ export function buildSkinMenuScript({ entries, activeId, styleId, menuId, cssTem
   const saved = loadCustom();
   if (saved) ensureCustomRow(saved);
 
-  button.addEventListener("click", () => {
-    panel.style.display = panel.style.display === "none" ? "block" : "none";
+  button.addEventListener("mousedown", (e) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const startRight = parseFloat(root.style.right || 0);
+    const startBottom = parseFloat(root.style.bottom || 0);
+    let moved = false;
+
+    const onMove = (ev) => {
+      const dx = ev.clientX - startX;
+      const dy = ev.clientY - startY;
+      if (!moved && Math.sqrt(dx * dx + dy * dy) > 4) {
+        moved = true;
+        panel.style.display = "none";
+      }
+      if (moved) {
+        root.style.right = Math.max(0, startRight - dx) + "px";
+        root.style.bottom = Math.max(0, startBottom - dy) + "px";
+      }
+    };
+    const onUp = () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      if (!moved) {
+        panel.style.display = panel.style.display === "none" ? "block" : "none";
+      }
+    };
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
   });
 
   root.append(button, panel, picker);


### PR DESCRIPTION
## 改动说明 / What

修复两个使用体验问题：

### 1. 🎨 主题切换菜单：移右下角 + 可拖动
- 原按钮固定在 `top:48px; right:16px`，会遮挡标题栏右上角的后退/搜索等按钮。
- 改为固定在**右下角** `bottom:16px; right:16px`（并加 `top:auto`）。
- 新增**拖拽**：在按钮上 `mousedown` 后移动超过 4px 即进入拖动，松开即停；未移动则正常切换菜单（点击行为不变）。

### 2. 遮住标题栏圆角处漏出的背景图
- 原 `#root` 背景最顶部会露出 hero 图片，与标题栏圆角不搭。
- 在背景最顶层新增一层 40px 的 `var(--wb-surface)` 遮罩；
- 同时把 hero 背景图整体向下偏移（`background-position` 末段 `right 32px`），双重保险避免顶部漏图。

## 改动文件 / Files changed
- `src/skin-menu.mjs`
- `src/skin-css.mjs`

仅 2 文件、+32/-3 行，不影响其他逻辑。